### PR TITLE
Convert 'string' var to string

### DIFF
--- a/src/PersianNumberWords.js
+++ b/src/PersianNumberWords.js
@@ -11,7 +11,7 @@ const numbers = {
 const delimiter = ' و ';
 
 function convert(input) {
-  let string = input;
+  let string = input + ''; // covert to string.
 
   string = string.split('')
     .reverse()


### PR DESCRIPTION
When you call this function with number input, It throws an error **'string.split is not a Function'**.
so before doing anything covert it to a string. 